### PR TITLE
Introduce improvements to reverse

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -51,31 +51,31 @@ function preserveEndingSlash(pattern, reversed) {
 }
 
 export function reverse(pattern, params = {}) {
-  if (checkEnv) {
-    checkKeys(pattern, params)
-  }
-  const reversed = (pattern.match(/:\w+\??/g) || [])
-    .reduce((url, key) => {
-      const optKey = key.replace(":", "").replace("?", "")
-      if (params[optKey] === undefined && key.indexOf("?") < 0) {
-        if (process.env.NODE_ENV === "development") {
-          console.warn(`Required parameter ${key} is missing for ${pattern}`)
+    if (checkEnv) {
+        checkKeys(pattern, params)
+    }
+    const reversed = pattern.replace(/\w*(:\w+\??)/g, function(path, param) {
+        const key = param.replace(/[:?]/g,'')
+        if (params[key] === undefined) {
+            if (param.indexOf('?') < 0) {
+                if (checkEnv) {
+                    console.warn(`Required parameter ${key} is missing for ${pattern}`)
+                }
+                return path
+            } else {
+                return ''
+            }
+        } else {
+            return path.replace(param, params[key])
         }
-        return url
-      } else {
-        return url.split(key).join(params[optKey] || "")
-      }
-    }, pattern)
-    .replace(/\/\//, "/")
-  return preserveEndingSlash(pattern, reversed)
+    }).replace(/\/\//, "/")
+    return preserveEndingSlash(pattern, reversed)
 }
 
 export function reverseForce(pattern, params = {}) {
-  const reversed = (pattern.match(/:\w+\??/g) || [])
-    .reduce((url, key) => {
-      const optKey = key.replace(":", "").replace("?", "")
-      return url.split(key).join(params[optKey] || "")
-    }, pattern)
-    .replace(/\/\//g, "/")
+  const reversed = pattern.replace(/\w*(:\w+\??)/g, function(path, param) {
+    const key = param.replace(/[:?]/g,'')
+    return params[key] ? path.replace(param, params[key]) : ''
+  }).replace(/\/\//g, "/")
   return preserveEndingSlash(pattern, reversed)
 }

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -18,6 +18,8 @@ describe("reverse", function() {
     expect(reverse("pattern/:param?/")).toEqual("pattern/")
     expect(reverse("a/:param?/b/:param", { param: 42 })).toEqual("a/42/b/42")
     expect(reverse("a/:param?/b")).toEqual("a/b")
+    expect(reverse('pattern/page:param?', {})).toEqual('pattern')
+      expect(reverse('pattern/page:param?/', {})).toEqual('pattern/')
   })
 })
 
@@ -120,5 +122,6 @@ describe("reverseForce", function() {
     expect(reverseForce("a/:param?/b/:param", { param: 42 })).toEqual(
       "a/42/b/42"
     )
+    expect(reverseForce('pattern/page:param', {})).toEqual('pattern')
   })
 })


### PR DESCRIPTION
I replaced `reduce` with `replace` since it's quite a bit faster when working with regex and does not require any additional defaults/fallbacks.  Also I slightly changed the functionality so that if the parameter is optional, it will remove not only the tag, but the whole url-block (i.e. `reverse('topics/:topicId/page:page', {topicId: 12})` will give `'topics/12'` instead of `'topics/12/page'`)