### PR TITLE
feat: reimplement reverse and reverseForce with path-to-regexp

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ There're other libs dealing with named routes, some of them provide custom
 - https://github.com/taion/use-named-routes
 - https://github.com/alubbe/named-routes
 
+> **NOTE:** v2 introduces breaking changes. Please check out the [migration guide](#migrating-from-v1xx-to-v2xx) before upgrading.
+
 ## Installation
 
 ```
@@ -129,7 +131,7 @@ function Navigation({ messages }) {
          <li><Link to={`${routes.profile}`}>Profile</Link></li>
          // ...
          // Use reverse to replace params in route pattern with values
-         {messages.map(message => 
+         {messages.map(message =>
             <li key={message.id}>
                <Link to={reverse(`${routes.messages.detail.show}`, { messageId: message.id })}>
                   Profile
@@ -156,6 +158,26 @@ reverse('pattern/:optional?') // pattern
 reverse('pattern/:optional?/', { optional: 42 }) // pattern/42/
 reverse('pattern/:optional?/') // pattern/
 ```
+
+## Migrating from v1.x.x to v2.x.x
+
+For better compatibility with React Router, v2 uses [path-to-regexp](https://github.com/pillarjs/path-to-regexp) to resolve URLs. This means some of your routes may break when you upgrade.
+
+### `reverse`
+
+```diff
+-reverse('pattern/page:param?', {})
++reverse('pattern/(page:param)?', {})
+```
+
+### `reverseForce`
+
+```diff
+-reverseForce('pattern/page:param?', {})
++reverseForce('pattern/(page:param)?', {})
+```
+
+To get a full overview of all accepted patterns, consult the [path-to-regexp](https://github.com/pillarjs/path-to-regexp) documentation.
 
 ## Some tricks
 

--- a/package.json
+++ b/package.json
@@ -54,5 +54,8 @@
   "release": {
     "branch": "master",
     "npmPublish": false
+  },
+  "dependencies": {
+    "path-to-regexp": "^6.1.0"
   }
 }

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -1,25 +1,29 @@
 import { include, reverse, reverseForce } from "."
 
-describe("reverse", function() {
-  it("should return original pattern when called without params", function() {
+describe("reverse", function () {
+  it("should return original pattern when called without params", function () {
     expect(reverse("pattern")).toEqual("pattern")
     expect(reverse("pattern/:param")).toEqual("pattern/:param")
   })
 
-  it("should replace params", function() {
+  it("should replace params", function () {
     expect(reverse("pattern/:param", { param: 42 })).toEqual("pattern/42")
     expect(reverse("a/:param/b/:param", { param: 42 })).toEqual("a/42/b/42")
   })
 
-  it("should replace optional params", function() {
+  it("should replace optional params", function () {
     expect(reverse("pattern/:param?", { param: 42 })).toEqual("pattern/42")
     expect(reverse("pattern/:param?/", { param: 42 })).toEqual("pattern/42/")
     expect(reverse("pattern/:param?")).toEqual("pattern")
     expect(reverse("pattern/:param?/")).toEqual("pattern/")
     expect(reverse("a/:param?/b/:param", { param: 42 })).toEqual("a/42/b/42")
     expect(reverse("a/:param?/b")).toEqual("a/b")
-    expect(reverse('pattern/page:param?', {})).toEqual('pattern')
-      expect(reverse('pattern/page:param?/', {})).toEqual('pattern/')
+    expect(reverse('pattern/(page:param)?', {})).toEqual('pattern')
+    expect(reverse('pattern/(page:param)?/', {})).toEqual('pattern/')
+  })
+
+  it("should escape validation patterns", function () {
+    expect(reverse("pattern/:param(\\d+)", { param: 42 })).toEqual("pattern/42")
   })
 })
 
@@ -122,6 +126,6 @@ describe("reverseForce", function() {
     expect(reverseForce("a/:param?/b/:param", { param: 42 })).toEqual(
       "a/42/b/42"
     )
-    expect(reverseForce('pattern/page:param', {})).toEqual('pattern')
+    expect(reverseForce('pattern/(page:param)?', {})).toEqual('pattern')
   })
 })

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -1,17 +1,17 @@
 import { include, reverse, reverseForce } from "."
 
-describe("reverse", function () {
-  it("should return original pattern when called without params", function () {
+describe("reverse", function() {
+  it("should return original pattern when called without params", function() {
     expect(reverse("pattern")).toEqual("pattern")
     expect(reverse("pattern/:param")).toEqual("pattern/:param")
   })
 
-  it("should replace params", function () {
+  it("should replace params", function() {
     expect(reverse("pattern/:param", { param: 42 })).toEqual("pattern/42")
     expect(reverse("a/:param/b/:param", { param: 42 })).toEqual("a/42/b/42")
   })
 
-  it("should replace optional params", function () {
+  it("should replace optional params", function() {
     expect(reverse("pattern/:param?", { param: 42 })).toEqual("pattern/42")
     expect(reverse("pattern/:param?/", { param: 42 })).toEqual("pattern/42/")
     expect(reverse("pattern/:param?")).toEqual("pattern")
@@ -22,7 +22,7 @@ describe("reverse", function () {
     expect(reverse('pattern/(page:param)?/', {})).toEqual('pattern/')
   })
 
-  it("should escape validation patterns", function () {
+  it("should escape validation patterns", function() {
     expect(reverse("pattern/:param(\\d+)", { param: 42 })).toEqual("pattern/42")
   })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -4534,6 +4534,11 @@ path-parse@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.5.tgz#3c1adf871ea9cd6c9431b6ea2bd74a0ff055c4c1"
 
+path-to-regexp@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-6.1.0.tgz#0b18f88b7a0ce0bfae6a25990c909ab86f512427"
+  integrity sha512-h9DqehX3zZZDCEm+xbfU0ZmwCGFCAAraPJWMXJ4+v32NjZJilVg3k1TcKsRgIb8IQ/izZSaydDc1OhJCZvs2Dw==
+
 path-type@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-1.1.0.tgz#59c44f7ee491da704da415da5a4070ba4f8fe441"


### PR DESCRIPTION
This PR reimplements the `reverse` and `reverseForce` methods using [path-to-regexp](https://github.com/pillarjs/path-to-regexp), the library that React Router uses under the hood.

It was initially intended to fix issue #16, but using the library revealed inconsistencies between the way `named-urls` and `path-to-regexp` interpret parameters (see https://github.com/tricoder42/named-urls/issues/16#issuecomment-557578958).

The decision moved in the direction of going with the React Router philosophy and adopting `path-to-regexp`, even though this means breaking BC.

Therefore, 3 unit tests have changed:

```
// Before

reverse('pattern/page:param?', {}) // 'pattern'
reverse('pattern/(page:param)?/', {}) // 'pattern/'

// After

reverse('pattern/page:param?', {}) // 'pattern/page'
reverse('pattern/page:param?/', {}) // 'pattern/page/'

// Workaround

reverse('pattern/(page:param)?', {}) // 'pattern'
reverse('pattern/(page:param)?/', {}) // 'pattern/'
```

**This breaks backwards compatibility and should be released in a new major version.**

fix #16 